### PR TITLE
Litronlasertiming#6090

### DIFF
--- a/dg645Sup/Makefile
+++ b/dg645Sup/Makefile
@@ -8,6 +8,7 @@ DB += dg645_logic.db
 DB += dg645_delay.db
 DB += dg645_width.db
 DB += dg645_delay_width_shared.db
+DB += litron.db
 
 #=======================================
 include $(TOP)/configure/RULES

--- a/dg645Sup/dg645_delay.db
+++ b/dg645Sup/dg645_delay.db
@@ -44,7 +44,7 @@ record(calcout,"$(P)$(R)$(Q)DELAYUNITOUT")
     field(INPB, "$(P)$(R)$(Q)DELAYUNIT:SP.RVAL")
     field(CALC, "A*(10^(-1*B))")
     field(OUT, "$(P)$(R)$(Q)DelayAO PP")
-	#field(ASG, "READONLY")
+	field(ASG, "READONLY")
 }
 
 record(fanout,"$(P)$(R)$(Q)DELAYBUTTON")

--- a/dg645Sup/dg645_delay.db
+++ b/dg645Sup/dg645_delay.db
@@ -44,7 +44,7 @@ record(calcout,"$(P)$(R)$(Q)DELAYUNITOUT")
     field(INPB, "$(P)$(R)$(Q)DELAYUNIT:SP.RVAL")
     field(CALC, "A*(10^(-1*B))")
     field(OUT, "$(P)$(R)$(Q)DelayAO PP")
-	field(ASG, "READONLY")
+	#field(ASG, "READONLY")
 }
 
 record(fanout,"$(P)$(R)$(Q)DELAYBUTTON")

--- a/dg645Sup/litron.db
+++ b/dg645Sup/litron.db
@@ -1,0 +1,6 @@
+record(calc, "$(P)$(R)SUMMED_DLAY")
+{
+    field(INPA, "$(P)$(R)$(chan1=A)DELAY:RB CP")
+    field(INPB, "$(P)$(R)$(chan2=C)DELAY:RB CP")
+    field(CALC, "A+B")
+}

--- a/dg645Sup/litron.db
+++ b/dg645Sup/litron.db
@@ -1,84 +1,139 @@
-record(calc, "$(P)$(R)SUMMED_DLAY")
+record(calc, "$(P)$(R)SUMMED_DELAY")
 {
-    field(INPA, "$(P)$(R)$(chan1=A)DELAY:RB CP MS")
-    field(INPB, "$(P)$(R)$(chan2=C)DELAY:RB CP MS")
-    field(CALC, "A+B")
+    field(DESC, "Add dA & dC")
+    field(INPA, "$(P)$(R)$(chan1=A)DLAY CP MS")
+    field(INPB, "$(P)$(R)$(chan2=C)DLAY CP MS")
+    field(CALC, "A+B") # Add ADELAY & CDELAY
     field(EGU, "us")
 }
 
 record(ai, "$(P)$(R)OFFSET")
 {
+    field(DESC, "User Offset")
     field(VAL, "0")
     field(EGU, "us")
 }
 
 record(ai, "$(P)$(R)DELAY")
 {
+    field(DESC, "User Delay")
     field(VAL, "0")
     field(EGU, "us")
 }
 
 record(calc, "$(P)$(R)SUMMED_VALUE")
 {
+    field(DESC, "Add Delay Offset")
     field(INPA, "$(P)$(R)DELAY CP")
     field(INPB, "$(P)$(R)OFFSET CP")
-    field(CALC, "A+B")
+    field(CALC, "A+B") # Add DELAY & OFFSET
     field(EGU, "us")
 }
 
 record(calc, "$(P)$(R)_MODE1CHECK")
 {
-    field(INPA, "$(P)$(R)$(chan2=C)DELAY:RB CP")
+    field(DESC, "Mode 1 Error Check")
+    field(INPA, "$(P)$(R)$(chan2=C)DLAY CP")
     field(INPB, "$(P)$(R)SUMMED_VALUE CP")
     field(CALC, "(A+B)>39900||B<0")
+    # If delay + summed_val bigger than 39900 or summed_val less than 0
 }
 
 record(calc, "$(P)$(R)_MODE2CHECK")
 {
-    field(INPA, "$(P)$(R)$(chan2=C)DELAY:RB CP")
+    field(DESC, "Mode 2 Error Check")
+    field(INPA, "$(P)$(R)$(chan2=C)DLAY CP")
     field(INPB, "$(P)$(R)SUMMED_VALUE CP")
     field(CALC, "B>39900||(A+B)<=0")
+    # If delay + summed_val less than or equal to 0 or summed_val bigger than 39900
 }
 
 record(calc, "$(P)$(R)_BOTHCHECKS")
 {
-    field(INPA, "$(P)$(R)SAVE_STATE CP")
+    field(DESC, "Mode 1 & 2 Error Check")
+    field(INPA, "$(P)$(R)SET_MODE CP")
     field(INPB, "$(P)$(R)_MODE1CHECK CP")
     field(INPC, "$(P)$(R)_MODE2CHECK CP")
     field(CALC, "(A=1)?B:C")
+    # If mode is 1 return _MODE1CHECK else _MODE2CHECK
 }
 
 record(calcout, "$(P)$(R)ERROR")
 {
-    field(INPA, "$(P)$(R)SAVE_STATE CP")
+    field(DESC, "Check Modes")
+    field(INPA, "$(P)$(R)SET_MODE CP")
     field(INPB, "$(P)$(R)_BOTHCHECKS")
-    field(CALC, "A=0||B")
+    field(CALC, "A=0||B") # If no error then write delay when set
     field(OOPT, "When Zero")
-    field(OUT, "$(P)$(R)WRITE_DELAY PP")
+    field(OUT, "$(P)$(R)_WRITE_DELAY PP")
     field(DOPT, "Use OCAL")
     field(OCAL, "1")
 }
 
-record(seq, "$(P)$(R)WRITE_DELAY")
+record(seq, "$(P)$(R)_WRITE_DELAY")
 {
+    field(DESC, "Update Delay")
     field(VAL, "0")
 
-    # 1) display set
-    # 2) units set
-    field(LNK2, "$(P)$(R)$(chan1=A)DELAYUNIT:SP")
-    field(DO2, "2")
-    # 3) set t0
-    field(LNK3, "$(P)$(R)$(chan1=A)REFERENCE:SP")
-    field(DO3, "T0")
-    # 4) set dlay A
-    field(LNK4, "$(P)$(R)$(chan1=A)DELAY:SP")
-    field(DOL4, "$(P)$(R)SUMMED_VALUE")
-    # 5) send
-    field(LNK5, "$(P)$(R)$(chan1=A)DELAYBUTTON")
+    # 1) Units set
+    field(LNK1, "$(P)$(R)$(chan1=A)DELAYUNIT:SP")
+    field(DO1, "2")
+    # 2) Set t0
+    field(LNK2, "$(P)$(R)$(chan1=A)REFERENCE:SP")
+    field(DO2, "0")
+    # 3) Set dlay A
+    field(LNK3, "$(P)$(R)$(chan1=A)DelayWriteAO")
+    field(DOL3, "$(P)$(R)SUMMED_VALUE")
+    # 4) Send
+    field(LNK4, "$(P)$(R)$(chan1=A)DELAYBUTTON")
+    field(DO4, "1")
+    # 5) *CLS (StatusClearBO)
+    field(LNK5, "$(P)$(R)StatusClearBO")
     field(DO5, "1")
-    # 6) *CLS StatusClearBO
-    field(LNK6, "$(P)$(R)StatusClearBO")
-    field(DO6, "1")
     
     field(SELM, "All")
+}
+
+record(calcout, "$(P)$(R)_MODE0CHECK")
+{
+    field(DESC, "Mode 0 Error Check")
+    field(INPA, "$(P)$(R)MODE")
+    field(INPB, "$(P)$(R)DELAY")
+    field(INPC, "$(P)$(R)OFFSET")
+    field(CALC, "A=1?A:(A=2?A:(B>ABS(C)?1:2))") # If mode 0 then choose which mode to change to
+    field(OUT, "$(P)$(R)SET_MODE PP")
+}
+
+record(longout, "$(P)$(R)SET_MODE") # Send command to device to load settings from specified slot
+{
+    field(DESC, "Load Settings from slot 0(default) - 9")
+    field(EGU, "")
+    field(DTYP, "asynInt32")
+    field(OUT, "@asyn($(PORT)) RECALL")
+}
+
+record(mbbo, "$(P)$(R)MODE")
+{
+    field(ZRST, "auto")
+    field(ONST, "1")
+    field(TWST, "2")
+    field(FLNK, "$(P)$(R)_MODE0CHECK")
+    field(PINI, "YES")
+    field(VAL, "0")
+}
+
+record(calc, "$(P)$(R)$(chan1=A)DLAY")
+{
+    field(INPA, "$(P)$(R)$(chan1=A)DelayAI CP MS") # Hardcoded to work with us
+    field(INPB, "1e6")
+    field(CALC, "A*B")
+    field(EGU, "us")
+}
+
+record(calc, "$(P)$(R)$(chan2=C)DLAY")
+{
+    field(INPA, "$(P)$(R)$(chan2=C)DelayAI CP MS")
+    field(INPB, "1e6")
+    field(CALC, "A*B")
+    field(EGU, "us")
 }

--- a/dg645Sup/litron.db
+++ b/dg645Sup/litron.db
@@ -42,17 +42,43 @@ record(calc, "$(P)$(R)_MODE2CHECK")
 
 record(calc, "$(P)$(R)_BOTHCHECKS")
 {
-
     field(INPA, "$(P)$(R)SAVE_STATE CP")
     field(INPB, "$(P)$(R)_MODE1CHECK CP")
     field(INPC, "$(P)$(R)_MODE2CHECK CP")
     field(CALC, "(A=1)?B:C")
-
 }
 
-record(calc, "$(P)$(R)ERROR")
+record(calcout, "$(P)$(R)ERROR")
 {
     field(INPA, "$(P)$(R)SAVE_STATE CP")
     field(INPB, "$(P)$(R)_BOTHCHECKS")
     field(CALC, "A=0||B")
+    field(OOPT, "When Zero")
+    field(OUT, "$(P)$(R)WRITE_DELAY PP")
+    field(DOPT, "Use OCAL")
+    field(OCAL, "1")
+}
+
+record(seq, "$(P)$(R)WRITE_DELAY")
+{
+    field(VAL, "0")
+
+    # 1) display set
+    # 2) units set
+    field(LNK2, "$(P)$(R)$(chan1=A)DELAYUNIT:SP")
+    field(DO2, "2")
+    # 3) set t0
+    field(LNK3, "$(P)$(R)$(chan1=A)REFERENCE:SP")
+    field(DO3, "T0")
+    # 4) set dlay A
+    field(LNK4, "$(P)$(R)$(chan1=A)DELAY:SP")
+    field(DOL4, "$(P)$(R)SUMMED_VALUE")
+    # 5) send
+    field(LNK5, "$(P)$(R)$(chan1=A)DELAYBUTTON")
+    field(DO5, "1")
+    # 6) *CLS StatusClearBO
+    field(LNK6, "$(P)$(R)StatusClearBO")
+    field(DO6, "1")
+    
+    field(SELM, "All")
 }

--- a/dg645Sup/litron.db
+++ b/dg645Sup/litron.db
@@ -1,8 +1,26 @@
+record(calc, "$(P)$(R)$(chan1=A)DLAYSCAL")
+{
+    field(DESC, "Scaled raw value of ADELAY")
+    field(INPA, "$(P)$(R)$(chan1=A)DelayAI CP MS") # This is raw value scaled to 'us'
+    field(INPB, "1e6")
+    field(CALC, "A*B")
+    field(EGU, "us")
+}
+
+record(calc, "$(P)$(R)$(chan2=C)DLAYSCAL")
+{
+    field(DESC, "Scaled raw value of CDELAY")
+    field(INPA, "$(P)$(R)$(chan2=C)DelayAI CP MS")
+    field(INPB, "1e6")
+    field(CALC, "A*B")
+    field(EGU, "us")
+}
+
 record(calc, "$(P)$(R)SUMMED_DELAY")
 {
     field(DESC, "Add dA & dC")
-    field(INPA, "$(P)$(R)$(chan1=A)DLAY CP MS")
-    field(INPB, "$(P)$(R)$(chan2=C)DLAY CP MS")
+    field(INPA, "$(P)$(R)$(chan1=A)DLAYSCAL CP MS")
+    field(INPB, "$(P)$(R)$(chan2=C)DLAYSCAL CP MS")
     field(CALC, "A+B") # Add ADELAY & CDELAY
     field(EGU, "us")
 }
@@ -30,22 +48,41 @@ record(calc, "$(P)$(R)SUMMED_VALUE")
     field(EGU, "us")
 }
 
+record(mbbo, "$(P)$(R)MODE")
+{
+    field(DESC, "Device Mode. auto|1|2")
+    field(ZRST, "auto")
+    field(ONST, "1")
+    field(TWST, "2")
+    field(FLNK, "$(P)$(R)_MODEAUTOCHECK") # When mode changes then check if in mode auto
+    field(PINI, "YES")
+    field(VAL, "0")
+}
+
+record(longout, "$(P)$(R)SET_MODE") # Send command to device to load settings from specified slot
+{
+    field(DESC, "Load Settings from slot 0(default) - 9")
+    field(EGU, "")
+    field(DTYP, "asynInt32")
+    field(OUT, "@asyn($(PORT)) RECALL") # *RCL
+}
+
 record(calc, "$(P)$(R)_MODE1CHECK")
 {
     field(DESC, "Mode 1 Error Check")
-    field(INPA, "$(P)$(R)$(chan2=C)DLAY CP")
+    field(INPA, "$(P)$(R)$(chan2=C)DLAYSCAL CP")
     field(INPB, "$(P)$(R)SUMMED_VALUE CP")
     field(CALC, "(A+B)>39900||B<0")
-    # If delay + summed_val bigger than 39900 or summed_val less than 0
+    # If delay + summed_val bigger than 39900 or summed_val less than 0 then error
 }
 
 record(calc, "$(P)$(R)_MODE2CHECK")
 {
     field(DESC, "Mode 2 Error Check")
-    field(INPA, "$(P)$(R)$(chan2=C)DLAY CP")
+    field(INPA, "$(P)$(R)$(chan2=C)DLAYSCAL CP")
     field(INPB, "$(P)$(R)SUMMED_VALUE CP")
     field(CALC, "B>39900||(A+B)<=0")
-    # If delay + summed_val less than or equal to 0 or summed_val bigger than 39900
+    # If delay + summed_val less than or equal to 0 or summed_val bigger than 39900 then error
 }
 
 record(calc, "$(P)$(R)_BOTHCHECKS")
@@ -81,7 +118,7 @@ record(seq, "$(P)$(R)_WRITE_DELAY")
     # 2) Set t0
     field(LNK2, "$(P)$(R)$(chan1=A)REFERENCE:SP")
     field(DO2, "0")
-    # 3) Set dlay A
+    # 3) Set delay A
     field(LNK3, "$(P)$(R)$(chan1=A)DelayWriteAO")
     field(DOL3, "$(P)$(R)SUMMED_VALUE")
     # 4) Send
@@ -94,46 +131,14 @@ record(seq, "$(P)$(R)_WRITE_DELAY")
     field(SELM, "All")
 }
 
-record(calcout, "$(P)$(R)_MODE0CHECK")
+record(calcout, "$(P)$(R)_MODEAUTOCHECK")
 {
     field(DESC, "Mode 0 Error Check")
     field(INPA, "$(P)$(R)MODE")
     field(INPB, "$(P)$(R)DELAY")
     field(INPC, "$(P)$(R)OFFSET")
-    field(CALC, "A=1?A:(A=2?A:(B>ABS(C)?1:2))") # If mode 0 then choose which mode to change to
+    field(CALC, "A=1?A:(A=2?A:(B>ABS(C)?1:2))")
+    # If mode is 1 or 2 then return 1 or 2
+    # Else if DELAY > OFFSET return 1 else 2
     field(OUT, "$(P)$(R)SET_MODE PP")
-}
-
-record(longout, "$(P)$(R)SET_MODE") # Send command to device to load settings from specified slot
-{
-    field(DESC, "Load Settings from slot 0(default) - 9")
-    field(EGU, "")
-    field(DTYP, "asynInt32")
-    field(OUT, "@asyn($(PORT)) RECALL")
-}
-
-record(mbbo, "$(P)$(R)MODE")
-{
-    field(ZRST, "auto")
-    field(ONST, "1")
-    field(TWST, "2")
-    field(FLNK, "$(P)$(R)_MODE0CHECK")
-    field(PINI, "YES")
-    field(VAL, "0")
-}
-
-record(calc, "$(P)$(R)$(chan1=A)DLAY")
-{
-    field(INPA, "$(P)$(R)$(chan1=A)DelayAI CP MS") # Hardcoded to work with us
-    field(INPB, "1e6")
-    field(CALC, "A*B")
-    field(EGU, "us")
-}
-
-record(calc, "$(P)$(R)$(chan2=C)DLAY")
-{
-    field(INPA, "$(P)$(R)$(chan2=C)DelayAI CP MS")
-    field(INPB, "1e6")
-    field(CALC, "A*B")
-    field(EGU, "us")
 }

--- a/dg645Sup/litron.db
+++ b/dg645Sup/litron.db
@@ -59,6 +59,18 @@ record(mbbo, "$(P)$(R)MODE")
     field(VAL, "0")
 }
 
+record(calcout, "$(P)$(R)_MODEAUTOCHECK")
+{
+    field(DESC, "Mode Auto Error Check")
+    field(INPA, "$(P)$(R)MODE")
+    field(INPB, "$(P)$(R)DELAY")
+    field(INPC, "$(P)$(R)OFFSET")
+    field(CALC, "A=1?A:(A=2?A:(B>ABS(C)?1:2))")
+    # If mode is 1 or 2 then return 1 or 2
+    # Else if DELAY > OFFSET return 1 else 2
+    field(OUT, "$(P)$(R)SET_MODE PP")
+}
+
 record(longout, "$(P)$(R)SET_MODE") # Send command to device to load settings from specified slot
 {
     field(DESC, "Load Settings from slot 0(default) - 9")
@@ -129,16 +141,4 @@ record(seq, "$(P)$(R)_WRITE_DELAY")
     field(DO5, "1")
     
     field(SELM, "All")
-}
-
-record(calcout, "$(P)$(R)_MODEAUTOCHECK")
-{
-    field(DESC, "Mode 0 Error Check")
-    field(INPA, "$(P)$(R)MODE")
-    field(INPB, "$(P)$(R)DELAY")
-    field(INPC, "$(P)$(R)OFFSET")
-    field(CALC, "A=1?A:(A=2?A:(B>ABS(C)?1:2))")
-    # If mode is 1 or 2 then return 1 or 2
-    # Else if DELAY > OFFSET return 1 else 2
-    field(OUT, "$(P)$(R)SET_MODE PP")
 }

--- a/dg645Sup/litron.db
+++ b/dg645Sup/litron.db
@@ -1,6 +1,58 @@
 record(calc, "$(P)$(R)SUMMED_DLAY")
 {
-    field(INPA, "$(P)$(R)$(chan1=A)DELAY:RB CP")
-    field(INPB, "$(P)$(R)$(chan2=C)DELAY:RB CP")
+    field(INPA, "$(P)$(R)$(chan1=A)DELAY:RB CP MS")
+    field(INPB, "$(P)$(R)$(chan2=C)DELAY:RB CP MS")
     field(CALC, "A+B")
+    field(EGU, "us")
+}
+
+record(ai, "$(P)$(R)OFFSET")
+{
+    field(VAL, "0")
+    field(EGU, "us")
+}
+
+record(ai, "$(P)$(R)DELAY")
+{
+    field(VAL, "0")
+    field(EGU, "us")
+}
+
+record(calc, "$(P)$(R)SUMMED_VALUE")
+{
+    field(INPA, "$(P)$(R)DELAY CP")
+    field(INPB, "$(P)$(R)OFFSET CP")
+    field(CALC, "A+B")
+    field(EGU, "us")
+}
+
+record(calc, "$(P)$(R)_MODE1CHECK")
+{
+    field(INPA, "$(P)$(R)$(chan2=C)DELAY:RB CP")
+    field(INPB, "$(P)$(R)SUMMED_VALUE CP")
+    field(CALC, "(A+B)>39900||B<0")
+}
+
+record(calc, "$(P)$(R)_MODE2CHECK")
+{
+    field(INPA, "$(P)$(R)$(chan2=C)DELAY:RB CP")
+    field(INPB, "$(P)$(R)SUMMED_VALUE CP")
+    field(CALC, "B>39900||(A+B)<=0")
+}
+
+record(calc, "$(P)$(R)_BOTHCHECKS")
+{
+
+    field(INPA, "$(P)$(R)SAVE_STATE CP")
+    field(INPB, "$(P)$(R)_MODE1CHECK CP")
+    field(INPC, "$(P)$(R)_MODE2CHECK CP")
+    field(CALC, "(A=1)?B:C")
+
+}
+
+record(calc, "$(P)$(R)ERROR")
+{
+    field(INPA, "$(P)$(R)SAVE_STATE CP")
+    field(INPB, "$(P)$(R)_BOTHCHECKS")
+    field(CALC, "A=0||B")
 }

--- a/system_tests/lewis_emulators/Dg645/interfaces/stream_interface.py
+++ b/system_tests/lewis_emulators/Dg645/interfaces/stream_interface.py
@@ -65,7 +65,12 @@ class Dg645StreamInterface(StreamInterface):
         # Commands below are only defined but not implemented because without it, the Delaygen
         # ASYN driver would crash
         CmdBuilder("get_prescale_factor").escape("PRES?").spaces().int().eos().build(),
-        CmdBuilder("get_prescale_phase_factor").escape("PHAS?").spaces().int().eos().build(),
+        CmdBuilder("get_prescale_phase_factor")
+        .escape("PHAS?")
+        .spaces()
+        .int()
+        .eos()
+        .build(),
         CmdBuilder("get_interface_config").escape("IFCF?").spaces().int().eos().build(),
         CmdBuilder("get_trigger_rate").escape("TRAT?").eos().build(),
         CmdBuilder("get_advanced_triggering_mode").escape("ADVT?").eos().build(),

--- a/system_tests/tests/dg645.py
+++ b/system_tests/tests/dg645.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingImports=false
 import unittest
 
 from parameterized import parameterized

--- a/system_tests/tests/dg645.py
+++ b/system_tests/tests/dg645.py
@@ -90,19 +90,29 @@ class Dg645Tests(unittest.TestCase):
         self.ca.assert_that_pv_is(channel + "OutputOffsetAI", -0)
 
     @parameterized.expand(parameterized_list(OUTPUT_CHANNELS))
-    def test_WHEN_polarity_button_pressed_THEN_correct_polarity_set_positive(self, _, channel):
+    def test_WHEN_polarity_button_pressed_THEN_correct_polarity_set_positive(
+        self, _, channel
+    ):
         self.ca.set_pv_value(channel + "OUTPUTPOLARITY:SP", 1)
         self.ca.assert_that_pv_is(channel + "OutputPolarityBI.RVAL", 1)
         self.ca.assert_that_pv_is(channel + "OUTPUTPOLARITY_OFF", 0)
 
     @parameterized.expand(parameterized_list(OUTPUT_CHANNELS))
-    def test_WHEN_polarity_button_pressed_THEN_correct_polarity_set_negative(self, _, channel):
+    def test_WHEN_polarity_button_pressed_THEN_correct_polarity_set_negative(
+        self, _, channel
+    ):
         self.ca.set_pv_value(channel + "OUTPUTPOLARITY:SP", 0)
         self.ca.assert_that_pv_is(channel + "OutputPolarityBI.RVAL", 0)
         self.ca.assert_that_pv_is(channel + "OUTPUTPOLARITY_OFF", 1)
 
     def calculate_delay(self, count, unit):
-        units_map = {"s": 1, "ms": 0.001, "us": 0.000001, "ns": 0.000000001, "ps": 0.000000000001}
+        units_map = {
+            "s": 1,
+            "ms": 0.001,
+            "us": 0.000001,
+            "ns": 0.000000001,
+            "ps": 0.000000000001,
+        }
         self.assertIn(unit, units_map, "Unexpected unit: " + str(unit))
         return round(count * units_map[unit], 12)
 
@@ -131,7 +141,9 @@ class Dg645Tests(unittest.TestCase):
     # Returns max delay of all channels set
     def set_all_channels(self, dataset):
         channels_to_set = DEVICE_CHANNELS[2:]
-        self.assertEqual(len(dataset), len(channels_to_set), "Incorrect dataset provided")
+        self.assertEqual(
+            len(dataset), len(channels_to_set), "Incorrect dataset provided"
+        )
         current_max = 0
         for i in range(len(dataset)):
             current_max = max(
@@ -157,7 +169,9 @@ class Dg645Tests(unittest.TestCase):
             ("H", "T0", 99, "ms"),
         ]
     )
-    def test_WHEN_delay_set_THEN_readback_correct(self, channel, reference, delay, unit):
+    def test_WHEN_delay_set_THEN_readback_correct(
+        self, channel, reference, delay, unit
+    ):
         self.set_channel_delay(channel, reference, delay, unit, True)
 
     # T1_delay = T0_delay + current_max_delay
@@ -227,7 +241,9 @@ class Dg645Tests(unittest.TestCase):
 
         # on valid settings, the depth should never reach 8
         self.assertLess(
-            depth, 8, "Endless reference loop detected in channel data. Test data invalid."
+            depth,
+            8,
+            "Endless reference loop detected in channel data. Test data invalid.",
         )
 
         # referencing T0 stops the search
@@ -246,7 +262,10 @@ class Dg645Tests(unittest.TestCase):
         self.assertEqual(
             expected,
             received,
-            "Delay width incorrect, expected: " + str(expected) + ", received: " + str(received),
+            "Delay width incorrect, expected: "
+            + str(expected)
+            + ", received: "
+            + str(received),
         )
 
     # Each channel has a width which is equal to this channel's delay plus delay of referenced channel
@@ -295,7 +314,9 @@ class Dg645Tests(unittest.TestCase):
         expected = abs(round(channel_a[1] - channel_b[1], 12))
         received = self.calculate_delay(
             self.ca.get_pv_value(channel_a[0] + channel_b[0] + "DELAYWIDTH:RB"),
-            self.ca.get_pv_value(channel_a[0] + channel_b[0] + "DELAYWIDTHUNIT" ":RB.SVAL"),
+            self.ca.get_pv_value(
+                channel_a[0] + channel_b[0] + "DELAYWIDTHUNIT" ":RB.SVAL"
+            ),
         )
         self.assertEqual(
             expected,

--- a/system_tests/tests/dg645_llt.py
+++ b/system_tests/tests/dg645_llt.py
@@ -37,8 +37,8 @@ class Dg645LLTTests(unittest.TestCase):
         self.ca.assert_that_pv_is("SUMMED_VALUE", 30)
 
     def test_Summed_Delay(self):
-        self.ca.set_pv_value("ADLAY", 10)
-        self.ca.set_pv_value("CDLAY", 20)
+        self.ca.set_pv_value("ADLAYSCAL", 10)
+        self.ca.set_pv_value("CDLAYSCAL", 20)
         self.ca.set_pv_value("ADELAYBUTTON", 1)
         self.ca.set_pv_value("CDELAYBUTTON", 1)
         self.ca.assert_that_pv_is("SUMMED_DELAY", 30)

--- a/system_tests/tests/dg645_llt.py
+++ b/system_tests/tests/dg645_llt.py
@@ -57,11 +57,9 @@ class Dg645LLTTests(unittest.TestCase):
         self.ca.set_pv_value("MODE", "auto")
         self.ca.assert_that_pv_is("SET_MODE", 2)
 
-    @parameterized.expand(
-        [(0, 39900, 100, 1), (40000, 0, 0, 1), (10, -1, 0, 1), (10, -5, 5, 0)]
-    )
-    def test_Mode_One_Error_Check(self, cDelay, delay, offset, err):
-        self.ca.set_pv_value("CDELAY:SP", cDelay)
+    @parameterized.expand([(0, 39900, 100, 1), (40000, 0, 0, 1), (10, -1, 0, 1), (10, -5, 5, 0)])
+    def test_Mode_One_Error_Check(self, cdelay, delay, offset, err):
+        self.ca.set_pv_value("CDELAY:SP", cdelay)
         self.ca.set_pv_value("CDELAYUNIT:SP", "us")
         self.ca.set_pv_value("CDELAYBUTTON", 1)
         self.ca.set_pv_value("OFFSET", offset)
@@ -79,8 +77,8 @@ class Dg645LLTTests(unittest.TestCase):
             (10, -5, -6, 1),
         ]
     )
-    def test_Mode_Two_Error_Check(self, cDelay, delay, offset, err):
-        self.ca.set_pv_value("CDELAY:SP", cDelay)
+    def test_Mode_Two_Error_Check(self, cdelay, delay, offset, err):
+        self.ca.set_pv_value("CDELAY:SP", cdelay)
         self.ca.set_pv_value("CDELAYUNIT:SP", "us")
         self.ca.set_pv_value("CDELAYBUTTON", 1)
         self.ca.set_pv_value("OFFSET", offset)

--- a/system_tests/tests/dg645_llt.py
+++ b/system_tests/tests/dg645_llt.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingImports=false
 import unittest
 
 from parameterized import parameterized

--- a/system_tests/tests/dg645_llt.py
+++ b/system_tests/tests/dg645_llt.py
@@ -4,8 +4,7 @@ from parameterized import parameterized
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import ProcServLauncher, get_default_ioc_dir
 from utils.test_modes import TestModes
-import time
-from utils.testing import get_running_lewis_and_ioc, parameterized_list
+from utils.testing import get_running_lewis_and_ioc
 
 DEVICE_PREFIX = "DG645_01"
 EMULATOR_NAME = "Dg645"
@@ -14,13 +13,16 @@ IOCS = [
     {
         "name": DEVICE_PREFIX,
         "directory": get_default_ioc_dir("DG645"),
-        "macros": {"APPLICATION":"LITRON",},
+        "macros": {
+            "APPLICATION": "LITRON",
+        },
         "emulator": EMULATOR_NAME,
         "ioc_launcher_class": ProcServLauncher,
     },
 ]
 
 TEST_MODES = [TestModes.DEVSIM]
+
 
 class Dg645LLTTests(unittest.TestCase):
     """
@@ -55,7 +57,9 @@ class Dg645LLTTests(unittest.TestCase):
         self.ca.set_pv_value("MODE", "auto")
         self.ca.assert_that_pv_is("SET_MODE", 2)
 
-    @parameterized.expand([(0, 39900, 100, 1),(40000, 0, 0, 1), (10, -1, 0, 1), (10, -5, 5, 0)])
+    @parameterized.expand(
+        [(0, 39900, 100, 1), (40000, 0, 0, 1), (10, -1, 0, 1), (10, -5, 5, 0)]
+    )
     def test_Mode_One_Error_Check(self, cDelay, delay, offset, err):
         self.ca.set_pv_value("CDELAY:SP", cDelay)
         self.ca.set_pv_value("CDELAYUNIT:SP", "us")
@@ -66,7 +70,15 @@ class Dg645LLTTests(unittest.TestCase):
         self.ca.set_pv_value("ERROR.PROC", "1")
         self.ca.assert_that_pv_is("ERROR", err)
 
-    @parameterized.expand([(0, 40000, 0, 1), (40000, 0, 0, 0), (0, 0, 0, 1), (10, -1, 0, 0), (10, -5, -6, 1)])
+    @parameterized.expand(
+        [
+            (0, 40000, 0, 1),
+            (40000, 0, 0, 0),
+            (0, 0, 0, 1),
+            (10, -1, 0, 0),
+            (10, -5, -6, 1),
+        ]
+    )
     def test_Mode_Two_Error_Check(self, cDelay, delay, offset, err):
         self.ca.set_pv_value("CDELAY:SP", cDelay)
         self.ca.set_pv_value("CDELAYUNIT:SP", "us")

--- a/system_tests/tests/dg645_llt.py
+++ b/system_tests/tests/dg645_llt.py
@@ -1,0 +1,78 @@
+import unittest
+
+from parameterized import parameterized
+from utils.channel_access import ChannelAccess
+from utils.ioc_launcher import ProcServLauncher, get_default_ioc_dir
+from utils.test_modes import TestModes
+import time
+from utils.testing import get_running_lewis_and_ioc, parameterized_list
+
+DEVICE_PREFIX = "DG645_01"
+EMULATOR_NAME = "Dg645"
+
+IOCS = [
+    {
+        "name": DEVICE_PREFIX,
+        "directory": get_default_ioc_dir("DG645"),
+        "macros": {"APPLICATION":"LITRON",},
+        "emulator": EMULATOR_NAME,
+        "ioc_launcher_class": ProcServLauncher,
+    },
+]
+
+TEST_MODES = [TestModes.DEVSIM]
+
+class Dg645LLTTests(unittest.TestCase):
+    """
+    Tests for the Dg645 Litron Laser Timing Control IOC.
+    """
+
+    def setUp(self):
+        self._lewis, self._ioc = get_running_lewis_and_ioc(EMULATOR_NAME, DEVICE_PREFIX)
+        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
+
+    def test_Summed_Value(self):
+        self.ca.set_pv_value("OFFSET", 10)
+        self.ca.set_pv_value("DELAY", 20)
+        self.ca.assert_that_pv_is("SUMMED_VALUE", 30)
+
+    def test_Summed_Delay(self):
+        self.ca.set_pv_value("ADLAY", 10)
+        self.ca.set_pv_value("CDLAY", 20)
+        self.ca.set_pv_value("ADELAYBUTTON", 1)
+        self.ca.set_pv_value("CDELAYBUTTON", 1)
+        self.ca.assert_that_pv_is("SUMMED_DELAY", 30)
+
+    def test_Mode_Zero_Change_Mode_To_One(self):
+        self.ca.set_pv_value("DELAY", 10)
+        self.ca.set_pv_value("OFFSET", 5)
+        self.ca.set_pv_value("MODE", "auto")
+        self.ca.assert_that_pv_is("SET_MODE", 1)
+
+    def test_Mode_Zero_Change_Mode_To_Two(self):
+        self.ca.set_pv_value("DELAY", 5)
+        self.ca.set_pv_value("OFFSET", 5)
+        self.ca.set_pv_value("MODE", "auto")
+        self.ca.assert_that_pv_is("SET_MODE", 2)
+
+    @parameterized.expand([(0, 39900, 100, 1),(40000, 0, 0, 1), (10, -1, 0, 1), (10, -5, 5, 0)])
+    def test_Mode_One_Error_Check(self, cDelay, delay, offset, err):
+        self.ca.set_pv_value("CDELAY:SP", cDelay)
+        self.ca.set_pv_value("CDELAYUNIT:SP", "us")
+        self.ca.set_pv_value("CDELAYBUTTON", 1)
+        self.ca.set_pv_value("OFFSET", offset)
+        self.ca.set_pv_value("DELAY", delay)
+        self.ca.set_pv_value("MODE", "1")
+        self.ca.set_pv_value("ERROR.PROC", "1")
+        self.ca.assert_that_pv_is("ERROR", err)
+
+    @parameterized.expand([(0, 40000, 0, 1), (40000, 0, 0, 0), (0, 0, 0, 1), (10, -1, 0, 0), (10, -5, -6, 1)])
+    def test_Mode_Two_Error_Check(self, cDelay, delay, offset, err):
+        self.ca.set_pv_value("CDELAY:SP", cDelay)
+        self.ca.set_pv_value("CDELAYUNIT:SP", "us")
+        self.ca.set_pv_value("CDELAYBUTTON", 1)
+        self.ca.set_pv_value("OFFSET", offset)
+        self.ca.set_pv_value("DELAY", delay)
+        self.ca.set_pv_value("MODE", "2")
+        self.ca.set_pv_value("ERROR.PROC", "1")
+        self.ca.assert_that_pv_is("ERROR", err)

--- a/system_tests/tests/dg645_llt.py
+++ b/system_tests/tests/dg645_llt.py
@@ -58,7 +58,9 @@ class Dg645LLTTests(unittest.TestCase):
         self.ca.set_pv_value("MODE", "auto")
         self.ca.assert_that_pv_is("SET_MODE", 2)
 
-    @parameterized.expand([(0, 39900, 100, 1), (40000, 0, 0, 1), (10, -1, 0, 1), (10, -5, 5, 0)])
+    @parameterized.expand(
+        [(0, 39900, 100, 1), (40000, 0, 0, 1), (10, -1, 0, 1), (10, -5, 5, 0)]
+    )
     def test_Mode_One_Error_Check(self, cdelay, delay, offset, err):
         self.ca.set_pv_value("CDELAY:SP", cdelay)
         self.ca.set_pv_value("CDELAYUNIT:SP", "us")


### PR DESCRIPTION
This adds a new db file to support control for Litron Laser Timing on the DG645 and additional system tests.

See https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Litron-Laser-Timing-Control-(Stanford-DG645) for new wiki page.

See https://github.com/ISISComputingGroup/IBEX/issues/6089#issuecomment-2102423879 for original LabView implementation.

See https://github.com/ISISComputingGroup/IBEX/issues/6090 for original ticket.

To test:
- Make sure that all system tests pass.
- Make sure that all logic in the original labview implementation has been represented here.
- Make sure that this has been tested on the actual device.