### PR TITLE
Dg645 litron timing fixes

### DIFF
--- a/dg645Sup/litron.db
+++ b/dg645Sup/litron.db
@@ -1,10 +1,21 @@
+record(bo, "$(P)$(R)ADelayAI:ForceScan") {
+    field(SCAN, ".2 second")
+    field(FLNK, "$(P)$(R)ADelayAI")
+}
+
+record(bo, "$(P)$(R)CDelayAI:ForceScan") {
+    field(SCAN, ".2 second")
+    field(FLNK, "$(P)$(R)CDelayAI")
+}
+
 record(calc, "$(P)$(R)$(chan1=A)DLAYSCAL")
 {
     field(DESC, "Scaled raw value of ADELAY")
     field(INPA, "$(P)$(R)$(chan1=A)DelayAI CP MS") # This is raw value scaled to 'us'
-    field(INPB, "1e6")
+    field(INPB, "1")
     field(CALC, "A*B")
     field(EGU, "us")
+    field(PREC, "6")
 }
 
 record(calc, "$(P)$(R)$(chan2=C)DLAYSCAL")
@@ -14,15 +25,7 @@ record(calc, "$(P)$(R)$(chan2=C)DLAYSCAL")
     field(INPB, "1e6")
     field(CALC, "A*B")
     field(EGU, "us")
-}
-
-record(calc, "$(P)$(R)SUMMED_DELAY")
-{
-    field(DESC, "Add dA & dC")
-    field(INPA, "$(P)$(R)$(chan1=A)DLAYSCAL CP MS")
-    field(INPB, "$(P)$(R)$(chan2=C)DLAYSCAL CP MS")
-    field(CALC, "A+B") # Add ADELAY & CDELAY
-    field(EGU, "us")
+    field(PREC, "6")
 }
 
 record(ai, "$(P)$(R)OFFSET")
@@ -30,6 +33,7 @@ record(ai, "$(P)$(R)OFFSET")
     field(DESC, "User Offset")
     field(VAL, "0")
     field(EGU, "us")
+    field(PREC, "6")
 }
 
 record(ai, "$(P)$(R)DELAY")
@@ -37,6 +41,7 @@ record(ai, "$(P)$(R)DELAY")
     field(DESC, "User Delay")
     field(VAL, "0")
     field(EGU, "us")
+    field(PREC, "6")
 }
 
 record(calc, "$(P)$(R)SUMMED_VALUE")
@@ -46,6 +51,27 @@ record(calc, "$(P)$(R)SUMMED_VALUE")
     field(INPB, "$(P)$(R)OFFSET CP")
     field(CALC, "A+B") # Add DELAY & OFFSET
     field(EGU, "us")
+    field(PREC, "6")
+}
+
+record(calc, "$(P)$(R)SUMMED_FINAL")
+{
+    field(DESC, "Add dA & dC") # CHANGE THIS
+    field(INPA, "$(P)$(R)SUMMED_VALUE CP")
+    field(INPB, "$(P)$(R)$(chan1=C)DLAYSCAL CP MS")
+    field(CALC, "A+B") # Add SUMMED_VALUE & CDELAY
+    field(EGU, "us")
+    field(PREC, "6")
+}
+
+record(calc, "$(P)$(R)SUMMED_DELAY")
+{
+    field(DESC, "Add dA & dC")
+    field(INPA, "$(P)$(R)$(chan1=A)DLAYSCAL CP MS")
+    field(INPB, "$(P)$(R)$(chan2=C)DLAYSCAL CP MS")
+    field(CALC, "A+B")
+    field(EGU, "us")
+    field(PREC, "6")
 }
 
 record(mbbo, "$(P)$(R)MODE")
@@ -69,7 +95,22 @@ record(calcout, "$(P)$(R)_MODEAUTOCHECK")
     # If mode is 1 or 2 then return 1 or 2
     # Else if DELAY > OFFSET return 1 else 2
     field(OUT, "$(P)$(R)SET_MODE PP")
+    # field(FLNK, "$(P)$(R)_UPDATE_SETPOINT")
 }
+
+# record(seq, "$(P)$(R)_UPDATE_SETPOINT"){
+
+#     field(LNK1, "$(P)$(R)$(chan1=A)DelayAI.PROC") 
+#     field(DO1, "1")
+
+#     field(LNK2, "$(P)$(R)$(chan2=C)DelayAI.PROC") 
+#     field(DO2, "1")
+
+#     field(LNK3, "$(P)$(R)$(chan1=A)DelayWriteAO PP")
+#     field(DLY3, ".5")
+#     field(DOL3, "$(P)$(R)$(P)$(R)$(chan2=C)DelayAI")
+
+# }
 
 record(longout, "$(P)$(R)SET_MODE") # Send command to device to load settings from specified slot
 {
@@ -107,13 +148,19 @@ record(calc, "$(P)$(R)_BOTHCHECKS")
     # If mode is 1 return _MODE1CHECK else _MODE2CHECK
 }
 
-record(calcout, "$(P)$(R)ERROR")
+record(calc, "$(P)$(R)ERROR")
 {
     field(DESC, "Check Modes")
     field(INPA, "$(P)$(R)SET_MODE CP")
     field(INPB, "$(P)$(R)_BOTHCHECKS")
-    field(CALC, "A=0||B") # If no error then write delay when set
-    field(OOPT, "When Zero")
+    field(CALC, "A=0||B")
+}
+
+record(calcout, "$(P)$(R)SET")
+{
+    field(INPA, "$(P)$(R)ERROR")
+    field(CALC, "A")
+    field(OOPT, "When Zero") # If no error then write delay when set
     field(OUT, "$(P)$(R)_WRITE_DELAY PP")
     field(DOPT, "Use OCAL")
     field(OCAL, "1")
@@ -125,20 +172,17 @@ record(seq, "$(P)$(R)_WRITE_DELAY")
     field(VAL, "0")
 
     # 1) Units set
-    field(LNK1, "$(P)$(R)$(chan1=A)DELAYUNIT:SP")
+    field(LNK1, "$(P)$(R)$(chan1=A)DELAYUNIT:SP PP")
     field(DO1, "2")
     # 2) Set t0
-    field(LNK2, "$(P)$(R)$(chan1=A)REFERENCE:SP")
+    field(LNK2, "$(P)$(R)$(chan1=A)REFERENCE:SP PP")
     field(DO2, "0")
     # 3) Set delay A
-    field(LNK3, "$(P)$(R)$(chan1=A)DelayWriteAO")
-    field(DOL3, "$(P)$(R)SUMMED_VALUE")
-    # 4) Send
-    field(LNK4, "$(P)$(R)$(chan1=A)DELAYBUTTON")
+    field(LNK3, "$(P)$(R)$(chan1=A)DelayWriteAO PP")
+    field(DOL3, "$(P)$(R)SUMMED_FINAL")
+    #4) *CLS (StatusClearBO)
+    field(LNK4, "$(P)$(R)StatusClearBO PP")
     field(DO4, "1")
-    # 5) *CLS (StatusClearBO)
-    field(LNK5, "$(P)$(R)StatusClearBO")
-    field(DO5, "1")
     
     field(SELM, "All")
 }

--- a/dg645Sup/litron.db
+++ b/dg645Sup/litron.db
@@ -95,22 +95,8 @@ record(calcout, "$(P)$(R)_MODEAUTOCHECK")
     # If mode is 1 or 2 then return 1 or 2
     # Else if DELAY > OFFSET return 1 else 2
     field(OUT, "$(P)$(R)SET_MODE PP")
-    # field(FLNK, "$(P)$(R)_UPDATE_SETPOINT")
+    field(FLNK, "$(P)$(R)ERROR")
 }
-
-# record(seq, "$(P)$(R)_UPDATE_SETPOINT"){
-
-#     field(LNK1, "$(P)$(R)$(chan1=A)DelayAI.PROC") 
-#     field(DO1, "1")
-
-#     field(LNK2, "$(P)$(R)$(chan2=C)DelayAI.PROC") 
-#     field(DO2, "1")
-
-#     field(LNK3, "$(P)$(R)$(chan1=A)DelayWriteAO PP")
-#     field(DLY3, ".5")
-#     field(DOL3, "$(P)$(R)$(P)$(R)$(chan2=C)DelayAI")
-
-# }
 
 record(longout, "$(P)$(R)SET_MODE") # Send command to device to load settings from specified slot
 {

--- a/dg645Sup/litron.db
+++ b/dg645Sup/litron.db
@@ -16,6 +16,8 @@ record(calc, "$(P)$(R)$(chan1=A)DLAYSCAL")
     field(CALC, "A*B")
     field(EGU, "us")
     field(PREC, "6")
+    field(ASG, "READONLY")
+    info(INTEREST, "HIGH")
 }
 
 record(calc, "$(P)$(R)$(chan2=C)DLAYSCAL")
@@ -26,6 +28,8 @@ record(calc, "$(P)$(R)$(chan2=C)DLAYSCAL")
     field(CALC, "A*B")
     field(EGU, "us")
     field(PREC, "6")
+    field(ASG, "READONLY")
+    info(INTEREST, "HIGH")
 }
 
 record(ai, "$(P)$(R)OFFSET")
@@ -34,6 +38,8 @@ record(ai, "$(P)$(R)OFFSET")
     field(VAL, "0")
     field(EGU, "us")
     field(PREC, "6")
+    info(autosaveFields, "VAL")
+    info(INTEREST, "HIGH")
 }
 
 record(ai, "$(P)$(R)DELAY")
@@ -42,6 +48,8 @@ record(ai, "$(P)$(R)DELAY")
     field(VAL, "0")
     field(EGU, "us")
     field(PREC, "6")
+    info(autosaveFields, "VAL")
+    info(INTEREST, "HIGH")
 }
 
 record(calc, "$(P)$(R)SUMMED_VALUE")
@@ -62,6 +70,8 @@ record(calc, "$(P)$(R)SUMMED_DELAY")
     field(CALC, "A+B")
     field(EGU, "us")
     field(PREC, "6")
+    field(ASG, "READONLY")
+    info(INTEREST, "HIGH")
 }
 
 record(mbbo, "$(P)$(R)MODE")
@@ -72,7 +82,8 @@ record(mbbo, "$(P)$(R)MODE")
     field(TWST, "2")
     field(FLNK, "$(P)$(R)_MODEAUTOCHECK") # When mode changes then check if in mode auto
     field(PINI, "YES")
-    field(VAL, "0")
+    info(autosaveFields, "VAL")
+    info(INTEREST, "HIGH")
 }
 
 record(calcout, "$(P)$(R)_MODEAUTOCHECK")
@@ -81,10 +92,9 @@ record(calcout, "$(P)$(R)_MODEAUTOCHECK")
     field(INPA, "$(P)$(R)MODE")
     field(INPB, "$(P)$(R)DELAY")
     field(INPC, "$(P)$(R)OFFSET")
-    # field(CALC, "A=1?A:(A=2?A:(B>ABS(C)?1:2))") Bring this back for use of auto
+    field(CALC, "A=1?A:(A=2?A:(B>ABS(C)?1:2))") # Bring this back for use of auto
     # If mode is 1 or 2 then return 1 or 2
     # Else if DELAY > OFFSET return 1 else 2
-    field(CALC, "A")
     field(OUT, "$(P)$(R)SET_MODE PP")
     field(FLNK, "$(P)$(R)ERROR")
 }
@@ -131,6 +141,8 @@ record(calc, "$(P)$(R)ERROR")
     field(INPA, "$(P)$(R)SET_MODE CP")
     field(INPB, "$(P)$(R)_BOTHCHECKS CP")
     field(CALC, "A=0||B")
+    info(INTEREST, "HIGH")
+    field(ASG, "READONLY")
 }
 
 record(calcout, "$(P)$(R)SET")

--- a/dg645Sup/litron.db
+++ b/dg645Sup/litron.db
@@ -54,16 +54,6 @@ record(calc, "$(P)$(R)SUMMED_VALUE")
     field(PREC, "6")
 }
 
-record(calc, "$(P)$(R)SUMMED_FINAL")
-{
-    field(DESC, "Add dA & dC") # CHANGE THIS
-    field(INPA, "$(P)$(R)SUMMED_VALUE CP")
-    field(INPB, "$(P)$(R)$(chan1=C)DLAYSCAL CP MS")
-    field(CALC, "A+B") # Add SUMMED_VALUE & CDELAY
-    field(EGU, "us")
-    field(PREC, "6")
-}
-
 record(calc, "$(P)$(R)SUMMED_DELAY")
 {
     field(DESC, "Add dA & dC")
@@ -91,9 +81,10 @@ record(calcout, "$(P)$(R)_MODEAUTOCHECK")
     field(INPA, "$(P)$(R)MODE")
     field(INPB, "$(P)$(R)DELAY")
     field(INPC, "$(P)$(R)OFFSET")
-    field(CALC, "A=1?A:(A=2?A:(B>ABS(C)?1:2))")
+    # field(CALC, "A=1?A:(A=2?A:(B>ABS(C)?1:2))") Bring this back for use of auto
     # If mode is 1 or 2 then return 1 or 2
     # Else if DELAY > OFFSET return 1 else 2
+    field(CALC, "A")
     field(OUT, "$(P)$(R)SET_MODE PP")
     field(FLNK, "$(P)$(R)ERROR")
 }

--- a/dg645Sup/litron.db
+++ b/dg645Sup/litron.db
@@ -12,7 +12,7 @@ record(calc, "$(P)$(R)$(chan1=A)DLAYSCAL")
 {
     field(DESC, "Scaled raw value of ADELAY")
     field(INPA, "$(P)$(R)$(chan1=A)DelayAI CP MS") # This is raw value scaled to 'us'
-    field(INPB, "1")
+    field(INPB, "1e6")
     field(CALC, "A*B")
     field(EGU, "us")
     field(PREC, "6")
@@ -49,7 +49,7 @@ record(calc, "$(P)$(R)SUMMED_VALUE")
     field(DESC, "Add Delay Offset")
     field(INPA, "$(P)$(R)DELAY CP")
     field(INPB, "$(P)$(R)OFFSET CP")
-    field(CALC, "A+B") # Add DELAY & OFFSET
+    field(CALC, "(A/1e6)+(B/1e6)") # Add DELAY & OFFSET
     field(EGU, "us")
     field(PREC, "6")
 }
@@ -111,7 +111,7 @@ record(calc, "$(P)$(R)_MODE1CHECK")
     field(DESC, "Mode 1 Error Check")
     field(INPA, "$(P)$(R)$(chan2=C)DLAYSCAL CP")
     field(INPB, "$(P)$(R)SUMMED_VALUE CP")
-    field(CALC, "(A+B)>39900||B<0")
+    field(CALC, "(A+(B*1e6))>39900||(B*1e6)<0")
     # If delay + summed_val bigger than 39900 or summed_val less than 0 then error
 }
 
@@ -120,7 +120,7 @@ record(calc, "$(P)$(R)_MODE2CHECK")
     field(DESC, "Mode 2 Error Check")
     field(INPA, "$(P)$(R)$(chan2=C)DLAYSCAL CP")
     field(INPB, "$(P)$(R)SUMMED_VALUE CP")
-    field(CALC, "B>39900||(A+B)<=0")
+    field(CALC, "(B*1e6)>39900||(A+B*1e6)<=0")
     # If delay + summed_val less than or equal to 0 or summed_val bigger than 39900 then error
 }
 
@@ -138,7 +138,7 @@ record(calc, "$(P)$(R)ERROR")
 {
     field(DESC, "Check Modes")
     field(INPA, "$(P)$(R)SET_MODE CP")
-    field(INPB, "$(P)$(R)_BOTHCHECKS")
+    field(INPB, "$(P)$(R)_BOTHCHECKS CP")
     field(CALC, "A=0||B")
 }
 
@@ -165,7 +165,7 @@ record(seq, "$(P)$(R)_WRITE_DELAY")
     field(DO2, "0")
     # 3) Set delay A
     field(LNK3, "$(P)$(R)$(chan1=A)DelayWriteAO PP")
-    field(DOL3, "$(P)$(R)SUMMED_FINAL")
+    field(DOL3, "$(P)$(R)SUMMED_VALUE")
     #4) *CLS (StatusClearBO)
     field(LNK4, "$(P)$(R)StatusClearBO PP")
     field(DO4, "1")

--- a/system_tests/tests/dg645_llt.py
+++ b/system_tests/tests/dg645_llt.py
@@ -35,57 +35,47 @@ class Dg645LLTTests(unittest.TestCase):
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
 
     def test_Summed_Value(self):
-        self.ca.set_pv_value("OFFSET", 10)
-        self.ca.set_pv_value("DELAY", 20)
-        self.ca.assert_that_pv_is("SUMMED_VALUE", 30)
+        self.ca.set_pv_value("DELAY", 10)
+        self.ca.set_pv_value("OFFSET", 20)
+        self.ca.set_pv_value("SET.PROC", "1")
+        self.ca.assert_that_pv_is("ADelayAO", 0.00003) 
 
     def test_Summed_Delay(self):
-        self.ca.set_pv_value("ADelayAO", 10)
+        self.ca.set_pv_value("ADelayAO", 0.00001)
         self.ca.set_pv_value("CDelayAO", 0.00002)
-        
         self.ca.assert_that_pv_is("SUMMED_DELAY", 30)
-
-    def test_Summed_Final(self):
-        self.ca.set_pv_value("CDelayAO", 0.00001)
-        
-        self.ca.set_pv_value("OFFSET", 10)
-        self.ca.set_pv_value("DELAY", 30)
-        self.ca.set_pv_value("MODE", "auto")
-        self.ca.set_pv_value("SET.PROC", "1")
-        self.ca.assert_that_pv_is("ADelayAI", 50) # Test that A delay = cdelay + delay + offset
-        self.ca.assert_that_pv_is("SUMMED_DELAY", 60) # 
 
     @parameterized.expand(
         [(0, 39900, 100, 1)]
     )
     def test_When_In_Error_Can_Not_Set_Delay(self, cdelay, delay, offset, err):
         self.ca.set_pv_value("CDelayAO", cdelay)
-        
+        self.ca.set_pv_value("ADelayAO", 0)
         self.ca.set_pv_value("OFFSET", offset)
         self.ca.set_pv_value("DELAY", delay)
         self.ca.set_pv_value("MODE", "1")
         self.ca.set_pv_value("SET.PROC", "1")
         self.ca.assert_that_pv_is("ERROR", err)
-        self.ca.set_pv_value("ADelayAO", 0)
+        self.ca.assert_that_pv_is("ADelayAO", 0)
 
-    def test_Mode_Zero_Change_Mode_To_One(self):
-        self.ca.set_pv_value("DELAY", 10)
-        self.ca.set_pv_value("OFFSET", 5)
-        self.ca.set_pv_value("MODE", "auto")
-        self.ca.assert_that_pv_is("SET_MODE", 1)
+    # Bring back for auto use
+    # def test_Mode_Auto_Change_Mode_To_One(self):
+    #     self.ca.set_pv_value("DELAY", 10)
+    #     self.ca.set_pv_value("OFFSET", 5)
+    #     self.ca.set_pv_value("MODE", "auto")
+    #     self.ca.assert_that_pv_is("SET_MODE", 1)
 
-    def test_Mode_Zero_Change_Mode_To_Two(self):
-        self.ca.set_pv_value("DELAY", 5)
-        self.ca.set_pv_value("OFFSET", 5)
-        self.ca.set_pv_value("MODE", "auto")
-        self.ca.assert_that_pv_is("SET_MODE", 2)
+    # def test_Mode_Auto_Change_Mode_To_Two(self):
+    #     self.ca.set_pv_value("DELAY", 5)
+    #     self.ca.set_pv_value("OFFSET", 5)
+    #     self.ca.set_pv_value("MODE", "auto")
+    #     self.ca.assert_that_pv_is("SET_MODE", 2)
 
     @parameterized.expand(
         [(0, 39900, 100, 1), (0.04, 0, 0, 1), (0.00001, -1, 0, 1), (0.00001, -5, 5, 0)]
     )
     def test_Mode_One_Error_Check(self, cdelay, delay, offset, err):
         self.ca.set_pv_value("CDelayAO", cdelay)
-        
         self.ca.set_pv_value("OFFSET", offset)
         self.ca.set_pv_value("DELAY", delay)
         self.ca.set_pv_value("MODE", "1")
@@ -103,7 +93,6 @@ class Dg645LLTTests(unittest.TestCase):
     )
     def test_Mode_Two_Error_Check(self, cdelay, delay, offset, err):
         self.ca.set_pv_value("CDelayAO", cdelay)
-        
         self.ca.set_pv_value("OFFSET", offset)
         self.ca.set_pv_value("DELAY", delay)
         self.ca.set_pv_value("MODE", "2")

--- a/system_tests/tests/dg645_llt.py
+++ b/system_tests/tests/dg645_llt.py
@@ -40,18 +40,33 @@ class Dg645LLTTests(unittest.TestCase):
         self.ca.assert_that_pv_is("SUMMED_VALUE", 30)
 
     def test_Summed_Delay(self):
-        self.ca.set_pv_value("ADLAYSCAL", 10)
-        self.ca.set_pv_value("CDLAYSCAL", 20)
-        self.ca.set_pv_value("ADELAYBUTTON", 1)
-        self.ca.set_pv_value("CDELAYBUTTON", 1)
+        self.ca.set_pv_value("ADelayAO", 10)
+        self.ca.set_pv_value("CDelayAO", 0.00002)
+        
         self.ca.assert_that_pv_is("SUMMED_DELAY", 30)
 
-    def test_Summed_Delay(self): # change for full total
-        self.ca.set_pv_value("CDLAY", 0.02)
+    def test_Summed_Final(self):
+        self.ca.set_pv_value("CDelayAO", 0.00001)
+        
         self.ca.set_pv_value("OFFSET", 10)
         self.ca.set_pv_value("DELAY", 30)
-        self.ca.set_pv_value("ADELAYBUTTON", 1)
-        self.ca.assert_that_pv_is("SUMMED_DELAY", 60)
+        self.ca.set_pv_value("MODE", "auto")
+        self.ca.set_pv_value("SET.PROC", "1")
+        self.ca.assert_that_pv_is("ADelayAI", 50) # Test that A delay = cdelay + delay + offset
+        self.ca.assert_that_pv_is("SUMMED_DELAY", 60) # 
+
+    @parameterized.expand(
+        [(0, 39900, 100, 1)]
+    )
+    def test_When_In_Error_Can_Not_Set_Delay(self, cdelay, delay, offset, err):
+        self.ca.set_pv_value("CDelayAO", cdelay)
+        
+        self.ca.set_pv_value("OFFSET", offset)
+        self.ca.set_pv_value("DELAY", delay)
+        self.ca.set_pv_value("MODE", "1")
+        self.ca.set_pv_value("SET.PROC", "1")
+        self.ca.assert_that_pv_is("ERROR", err)
+        self.ca.set_pv_value("ADelayAO", 0)
 
     def test_Mode_Zero_Change_Mode_To_One(self):
         self.ca.set_pv_value("DELAY", 10)
@@ -66,33 +81,31 @@ class Dg645LLTTests(unittest.TestCase):
         self.ca.assert_that_pv_is("SET_MODE", 2)
 
     @parameterized.expand(
-        [(0, 39900, 100, 1), (40000, 0, 0, 1), (10, -1, 0, 1), (10, -5, 5, 0)]
+        [(0, 39900, 100, 1), (0.04, 0, 0, 1), (0.00001, -1, 0, 1), (0.00001, -5, 5, 0)]
     )
     def test_Mode_One_Error_Check(self, cdelay, delay, offset, err):
-        self.ca.set_pv_value("CDELAY:SP", cdelay)
-        self.ca.set_pv_value("CDELAYUNIT:SP", "us")
-        self.ca.set_pv_value("CDELAYBUTTON", 1)
+        self.ca.set_pv_value("CDelayAO", cdelay)
+        
         self.ca.set_pv_value("OFFSET", offset)
         self.ca.set_pv_value("DELAY", delay)
         self.ca.set_pv_value("MODE", "1")
-        self.ca.set_pv_value("ERROR.PROC", "1")
+        self.ca.set_pv_value("SET.PROC", "1")
         self.ca.assert_that_pv_is("ERROR", err)
 
     @parameterized.expand(
         [
             (0, 40000, 0, 1),
-            (40000, 0, 0, 0),
+            (0.04, 0, 0, 0),
             (0, 0, 0, 1),
-            (10, -1, 0, 0),
-            (10, -5, -6, 1),
+            (0.00001, -1, 0, 0),
+            (0.00001, -5, -6, 1),
         ]
     )
     def test_Mode_Two_Error_Check(self, cdelay, delay, offset, err):
-        self.ca.set_pv_value("CDELAY:SP", cdelay)
-        self.ca.set_pv_value("CDELAYUNIT:SP", "us")
-        self.ca.set_pv_value("CDELAYBUTTON", 1)
+        self.ca.set_pv_value("CDelayAO", cdelay)
+        
         self.ca.set_pv_value("OFFSET", offset)
         self.ca.set_pv_value("DELAY", delay)
         self.ca.set_pv_value("MODE", "2")
-        self.ca.set_pv_value("ERROR.PROC", "1")
+        self.ca.set_pv_value("SET.PROC", "1")
         self.ca.assert_that_pv_is("ERROR", err)

--- a/system_tests/tests/dg645_llt.py
+++ b/system_tests/tests/dg645_llt.py
@@ -46,6 +46,13 @@ class Dg645LLTTests(unittest.TestCase):
         self.ca.set_pv_value("CDELAYBUTTON", 1)
         self.ca.assert_that_pv_is("SUMMED_DELAY", 30)
 
+    def test_Summed_Delay(self): # change for full total
+        self.ca.set_pv_value("CDLAY", 0.02)
+        self.ca.set_pv_value("OFFSET", 10)
+        self.ca.set_pv_value("DELAY", 30)
+        self.ca.set_pv_value("ADELAYBUTTON", 1)
+        self.ca.assert_that_pv_is("SUMMED_DELAY", 60)
+
     def test_Mode_Zero_Change_Mode_To_One(self):
         self.ca.set_pv_value("DELAY", 10)
         self.ca.set_pv_value("OFFSET", 5)

--- a/system_tests/tests/dg645_llt.py
+++ b/system_tests/tests/dg645_llt.py
@@ -38,16 +38,14 @@ class Dg645LLTTests(unittest.TestCase):
         self.ca.set_pv_value("DELAY", 10)
         self.ca.set_pv_value("OFFSET", 20)
         self.ca.set_pv_value("SET.PROC", "1")
-        self.ca.assert_that_pv_is("ADelayAO", 0.00003) 
+        self.ca.assert_that_pv_is("ADelayAO", 0.00003)
 
     def test_Summed_Delay(self):
         self.ca.set_pv_value("ADelayAO", 0.00001)
         self.ca.set_pv_value("CDelayAO", 0.00002)
         self.ca.assert_that_pv_is("SUMMED_DELAY", 30)
 
-    @parameterized.expand(
-        [(0, 39900, 100, 1)]
-    )
+    @parameterized.expand([(0, 39900, 100, 1)])
     def test_When_In_Error_Can_Not_Set_Delay(self, cdelay, delay, offset, err):
         self.ca.set_pv_value("CDelayAO", cdelay)
         self.ca.set_pv_value("ADelayAO", 0)
@@ -58,18 +56,17 @@ class Dg645LLTTests(unittest.TestCase):
         self.ca.assert_that_pv_is("ERROR", err)
         self.ca.assert_that_pv_is("ADelayAO", 0)
 
-    # Bring back for auto use
-    # def test_Mode_Auto_Change_Mode_To_One(self):
-    #     self.ca.set_pv_value("DELAY", 10)
-    #     self.ca.set_pv_value("OFFSET", 5)
-    #     self.ca.set_pv_value("MODE", "auto")
-    #     self.ca.assert_that_pv_is("SET_MODE", 1)
+    def test_Mode_Auto_Change_Mode_To_One(self):
+        self.ca.set_pv_value("DELAY", 10)
+        self.ca.set_pv_value("OFFSET", 5)
+        self.ca.set_pv_value("MODE", "auto")
+        self.ca.assert_that_pv_is("SET_MODE", 1)
 
-    # def test_Mode_Auto_Change_Mode_To_Two(self):
-    #     self.ca.set_pv_value("DELAY", 5)
-    #     self.ca.set_pv_value("OFFSET", 5)
-    #     self.ca.set_pv_value("MODE", "auto")
-    #     self.ca.assert_that_pv_is("SET_MODE", 2)
+    def test_Mode_Auto_Change_Mode_To_Two(self):
+        self.ca.set_pv_value("DELAY", 5)
+        self.ca.set_pv_value("OFFSET", 5)
+        self.ca.set_pv_value("MODE", "auto")
+        self.ca.assert_that_pv_is("SET_MODE", 2)
 
     @parameterized.expand(
         [(0, 39900, 100, 1), (0.04, 0, 0, 1), (0.00001, -1, 0, 1), (0.00001, -5, 5, 0)]


### PR DESCRIPTION
Corrections to the litron timing control IOC and unit tests. These changes adhere better to the original spec at https://github.com/ISISComputingGroup/IBEX/issues/6089#issuecomment-2102423879 .

- Set precisions to 6
- Separate ERROR into SET & ERROR
- Added PP to output links where necessary
- Don't write to explicit set button on low-level PVs
- Add records that scan readbacks
- Delay A is calculated as Delay + Offset (Summed Value)
- Summed delay is calculated as Delay A + Delay C
- Various fixes to scaling factors on delays

Check that unit tests pass, that there are enough of them and that the specification is adhered to now.

Wiki: https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Litron-Laser-Timing-Control-(Stanford-DG645)